### PR TITLE
DB init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 HELP.md
-
+compose-init.yaml
 # Maven
 target/
 .mvn/wrapper/maven-wrapper.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mvn dependency:go-offline
 COPY backend ./backend
 
 # Compila y empaqueta la aplicación en un JAR ejecutable.
-RUN mvn clean package
+RUN mvn clean package -DskipTests
 
 # ----- Run Stage -----
 FROM eclipse-temurin:21-jre-alpine

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ curl http://localhost:8080/actuator/health
 
 Y viendo que el status devuelto sea UP.
 
-Para incializar la DB con datos: ``` bash  docker compose -f compose.yaml -f compose-init.yaml up ```
+Para incializar la DB con datos: ``` docker compose -f compose.yaml -f compose-init.yaml up ```
 
 ## Entrega 2 - Interfaz de Usuario (UI)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ curl http://localhost:8080/actuator/health
 
 Y viendo que el status devuelto sea UP.
 
+Para incializar la DB con datos: ``` bash  docker compose -f compose.yaml -f compose-init.yaml up ```
+
 ## Entrega 2 - Interfaz de Usuario (UI)
 
 ### Configuración del Frontend

--- a/backend/src/main/java/org/utn/ba/tptacsg2/Tptacsg2Application.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/Tptacsg2Application.java
@@ -4,12 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
-@SpringBootApplication(exclude = {
-        MongoAutoConfiguration.class,
-        MongoDataAutoConfiguration.class,
-       // SecurityAutoConfiguration.class
-})
+@SpringBootApplication
 public class Tptacsg2Application {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/org/utn/ba/tptacsg2/config/DatabaseSeeder.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/config/DatabaseSeeder.java
@@ -1,0 +1,170 @@
+package org.utn.ba.tptacsg2.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import org.utn.ba.tptacsg2.models.actors.Organizador;
+import org.utn.ba.tptacsg2.models.actors.Participante;
+import org.utn.ba.tptacsg2.models.events.*;
+import org.utn.ba.tptacsg2.models.inscriptions.*;
+import org.utn.ba.tptacsg2.models.users.Rol;
+import org.utn.ba.tptacsg2.models.users.Usuario;
+import org.utn.ba.tptacsg2.repositories.db.*; // Asume que tienes todos los repositorios definidos
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+@ConditionalOnProperty(
+        name = "spring.application.db-init-enabled",
+        havingValue = "true",
+        matchIfMissing = false
+)
+public class DatabaseSeeder implements CommandLineRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(DatabaseSeeder.class);
+
+    private final UsuarioRepositoryDB usuarioRepository;
+    private final OrganizadorRepositoryDB organizadorRepository;
+    private final ParticipanteRepositoryDB participanteRepository;
+    private final EventoRepositoryDB eventoRepositoryDB;
+    private final EstadoEventoRepositoryDB estadoEventoRepository;
+    private final InscripcionRepositoryDB inscripcionRepository;
+    private final EstadoInscripcionRepositoryDB estadoInscripcionRepositoryDB;
+
+    public DatabaseSeeder(
+            UsuarioRepositoryDB usuarioRepository,
+            OrganizadorRepositoryDB organizadorRepository,
+            ParticipanteRepositoryDB participanteRepository,
+            EventoRepositoryDB eventoRepositoryDB,
+            EstadoEventoRepositoryDB estadoEventoRepository,
+            InscripcionRepositoryDB inscripcionRepository,
+            EstadoInscripcionRepositoryDB estadoInscripcionRepositoryDB
+    ) {
+        this.usuarioRepository = usuarioRepository;
+        this.organizadorRepository = organizadorRepository;
+        this.participanteRepository = participanteRepository;
+        this.eventoRepositoryDB = eventoRepositoryDB;
+        this.estadoEventoRepository = estadoEventoRepository;
+        this.inscripcionRepository = inscripcionRepository;
+        this.estadoInscripcionRepositoryDB = estadoInscripcionRepositoryDB;
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        log.info("Iniciando la inicialización de la base de datos...");
+
+        // 1. Limpiar todas las colecciones para un inicio limpio
+        cleanUp();
+
+        // 2. Crear Usuarios, Organizadores y Participantes
+        Usuario admin = new Usuario( "admin", "$argon2id$v=19$m=65536,t=4,p=1$Y6QXibp2pRk+u6XDSSX6Wg$vaFyKiCj6Tvl06OGHuJtPaw5+4iZDi4f2iN0jrsYYLs", Rol.ROLE_ADMIN);
+        Usuario userPart = new Usuario( "usuario", "$argon2id$v=19$m=65536,t=4,p=1$hC1J7qKqgmkSUfl8kMdQow$wva2eKpy3Mw8/oJPvJw5JdPse+cEJ73EdmcT6uhcXmU", Rol.ROLE_USER);
+        Usuario userOrg = new Usuario( "organizador", "$argon2id$v=19$m=65536,t=4,p=1$IDXLIGuWc88CLL+7VyhCOA$CXr5e1xeozTTolyjDn1PNX1cs9uHqXFbH6TrtDKOCtk", Rol.ROLE_ORGANIZER);
+
+        List<Usuario> savedUsers = usuarioRepository.saveAll(Arrays.asList(userOrg, userPart, admin));
+
+        Usuario savedUserOrg = savedUsers.stream()
+                .filter(u -> u.username().equals("organizador"))
+                .findFirst().orElseThrow();
+        Usuario savedUserPart = savedUsers.stream()
+                .filter(u -> u.username().equals("usuario"))
+                .findFirst().orElseThrow();
+
+        Organizador organizador = new Organizador(
+                "Juan", "Perez", "12345678", savedUserOrg
+        );
+        Participante participante = new Participante(
+                "Maria", "Gomez", "87654321", savedUserPart
+        );
+
+        // ✅ CORRECCIÓN 1: Capturar el ID del organizador y participante para usarlos en Evento e Inscripción.
+        organizador = organizadorRepository.save(organizador);
+        participante = participanteRepository.save(participante);
+
+        log.info("Usuarios, Organizadores y Participantes creados.");
+
+
+        // 3. Crear EstadoEvento y Evento
+        EstadoEvento estadoEvento = new EstadoEvento(
+                TipoEstadoEvento.CONFIRMADO,
+                LocalDateTime.now()
+        );
+        // ✅ CORRECCIÓN 2: Capturar el ID de EstadoEvento. (Esto ya lo tenías bien)
+        estadoEvento = estadoEventoRepository.save(estadoEvento);
+
+        Ubicacion ubicacion = new Ubicacion("34.6037", "58.3816", "CABA", "Av. 9 de Julio 1234");
+        Precio precio = new Precio("ARS", 1500.0f);
+        Categoria categoria = new Categoria("Conferencia");
+
+        Evento evento = new Evento(
+                "15616515611",
+                "Charla sobre microservicios con Spring Boot y MongoDB.",
+                "Un Evento que no te podes perder",
+                LocalDateTime.now().plusDays(7),
+                "10:00",
+                2.5f,
+                ubicacion,
+                100,
+                10,
+                precio,
+                organizador, // 👈 organizador tiene ID gracias a la Corrección 1
+                estadoEvento, // 👈 estadoEvento tiene ID
+                categoria,
+                Arrays.asList("Java", "Spring", "Microservicios")
+        );
+
+        // ✅ CORRECCIÓN 3: Capturar el ID de Evento. (Esto ya lo tenías bien)
+        evento = eventoRepositoryDB.save(evento);
+
+        // Finalizar la referencia circular de EstadoEvento a Evento (ambos tienen ID).
+        estadoEvento.setEvento(evento);
+        estadoEventoRepository.save(estadoEvento);
+
+        log.info("Evento y EstadoEvento creados.");
+
+
+        // 4. Crear EstadoInscripcion e Inscripcion
+        EstadoInscripcion estadoInscripcion = new EstadoInscripcion(
+                "885558888",
+                TipoEstadoInscripcion.ACEPTADA,
+                LocalDateTime.now()
+        );
+        // ✅ CORRECCIÓN 4: Capturar el ID de EstadoInscripcion. (Esto ya lo tenías bien)
+        estadoInscripcion = estadoInscripcionRepositoryDB.save(estadoInscripcion);
+
+        Inscripcion inscripcion = new Inscripcion(
+                participante, // 👈 participante tiene ID gracias a la Corrección 1
+                LocalDateTime.now(),
+                estadoInscripcion, // 👈 estadoInscripcion tiene ID
+                evento // 👈 evento tiene ID
+        );
+
+        // ✅ CORRECCIÓN 5: Capturar el ID de Inscripcion. (Esto ya lo tenías bien)
+        inscripcion = inscripcionRepository.save(inscripcion);
+
+        // Finalizar la referencia circular de EstadoInscripcion a Inscripcion (ambos tienen ID).
+        estadoInscripcion.setInscripcion(inscripcion);
+        estadoInscripcionRepositoryDB.save(estadoInscripcion);
+
+        log.info("Inscripción y EstadoInscripcion creados.");
+
+        log.info("Base de datos inicializada con datos de ejemplo.");
+    }
+
+    private void cleanUp() {
+        // Elimina todos los documentos de cada colección para evitar duplicados en cada inicio.
+        inscripcionRepository.deleteAll();
+        estadoInscripcionRepositoryDB.deleteAll();
+        eventoRepositoryDB.deleteAll();
+        estadoEventoRepository.deleteAll();
+        participanteRepository.deleteAll();
+        organizadorRepository.deleteAll();
+        usuarioRepository.deleteAll();
+        log.info("Colecciones limpiadas.");
+    }
+}

--- a/backend/src/main/java/org/utn/ba/tptacsg2/models/actors/Organizador.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/models/actors/Organizador.java
@@ -16,4 +16,8 @@ public record Organizador (
      String dni,
      @DBRef
      Usuario usuario
-){}
+){
+    public Organizador (String nombre, String apellido, String dni, Usuario usuario){
+        this(null, nombre, apellido, dni, usuario);
+    }
+}

--- a/backend/src/main/java/org/utn/ba/tptacsg2/models/actors/Organizador.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/models/actors/Organizador.java
@@ -1,11 +1,19 @@
 package org.utn.ba.tptacsg2.models.actors;
 
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
 import org.utn.ba.tptacsg2.models.users.Usuario;
 
+
+
+@Document(collection = "organizadores")
 public record Organizador (
+     @Id
      String id,
      String nombre,
      String apellido,
      String dni,
+     @DBRef
      Usuario usuario
 ){}

--- a/backend/src/main/java/org/utn/ba/tptacsg2/models/actors/Participante.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/models/actors/Participante.java
@@ -15,4 +15,7 @@ public record Participante(
         @DBRef
         Usuario usuario
 ) {
+    public Participante (String nombre, String apellido, String dni, Usuario usuario){
+        this(null, nombre, apellido, dni, usuario);
+    }
 }

--- a/backend/src/main/java/org/utn/ba/tptacsg2/models/actors/Participante.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/models/actors/Participante.java
@@ -1,12 +1,18 @@
 package org.utn.ba.tptacsg2.models.actors;
 
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
 import org.utn.ba.tptacsg2.models.users.Usuario;
 
+@Document(collection = "participantes")
 public record Participante(
+        @Id
         String id,
         String nombre,
         String apellido,
         String dni,
+        @DBRef
         Usuario usuario
 ) {
 }

--- a/backend/src/main/java/org/utn/ba/tptacsg2/models/events/EstadoEvento.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/models/events/EstadoEvento.java
@@ -3,15 +3,20 @@ package org.utn.ba.tptacsg2.models.events;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jdk.jfr.Event;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
-
+@Document(collation = "estadoeventos")
 public class EstadoEvento {
+    @Id
     private String id;
     private TipoEstadoEvento tipoEstado;
     private LocalDateTime fechaCambio;
 
     @JsonBackReference
+    @DBRef
     private Evento evento;
 
     public EstadoEvento() {}

--- a/backend/src/main/java/org/utn/ba/tptacsg2/models/events/EstadoEvento.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/models/events/EstadoEvento.java
@@ -33,6 +33,10 @@ public class EstadoEvento {
         this.tipoEstado = tipoEstado;
         this.fechaCambio = fechaCambio;
     }
+    public EstadoEvento(TipoEstadoEvento tipoEstado, LocalDateTime fechaCambio) {
+        this.tipoEstado = tipoEstado;
+        this.fechaCambio = fechaCambio;
+    }
 
     public Evento getEvento() {
         return evento;

--- a/backend/src/main/java/org/utn/ba/tptacsg2/models/events/Evento.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/models/events/Evento.java
@@ -1,13 +1,17 @@
 package org.utn.ba.tptacsg2.models.events;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
 import org.utn.ba.tptacsg2.models.actors.Organizador;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-
+@Document(collation = "eventos")
 public record Evento (
+     @Id
      String id,
      String titulo,
      String descripcion,
@@ -18,8 +22,10 @@ public record Evento (
      Integer cupoMaximo,
      Integer cupoMinimo,
      Precio precio,
+     @DBRef
      Organizador organizador,
      @JsonManagedReference
+     @DBRef
      EstadoEvento estado,
      Categoria categoria,
      List<String> etiquetas

--- a/backend/src/main/java/org/utn/ba/tptacsg2/models/events/Evento.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/models/events/Evento.java
@@ -29,4 +29,5 @@ public record Evento (
      EstadoEvento estado,
      Categoria categoria,
      List<String> etiquetas
-) {}
+) {
+}

--- a/backend/src/main/java/org/utn/ba/tptacsg2/models/inscriptions/EstadoInscripcion.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/models/inscriptions/EstadoInscripcion.java
@@ -1,11 +1,17 @@
 package org.utn.ba.tptacsg2.models.inscriptions;
 
-import java.time.LocalDateTime;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.LocalDateTime;
+@Document(collation = "estadoinscripciones")
 public class EstadoInscripcion {
 
+    @Id
     private final String id;
     private TipoEstadoInscripcion tipoEstado;
+    @DBRef
     private Inscripcion inscripcion; //TODO hacer un DTO sin la inscripcion para evitar referencias circulares en JSON
     private LocalDateTime fechaDeCambio;
 

--- a/backend/src/main/java/org/utn/ba/tptacsg2/models/inscriptions/Inscripcion.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/models/inscriptions/Inscripcion.java
@@ -1,15 +1,22 @@
 package org.utn.ba.tptacsg2.models.inscriptions;
 
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
 import org.utn.ba.tptacsg2.models.actors.Participante;
 import org.utn.ba.tptacsg2.models.events.Evento;
 
 import java.time.LocalDateTime;
-
+@Document(collation = "inscripciones")
 public record Inscripcion (
+        @Id
         String id,
+        @DBRef
         Participante participante,
         LocalDateTime fechaRegistro,
+        @DBRef
         EstadoInscripcion estado,
+        @DBRef
         Evento evento
 ){
 

--- a/backend/src/main/java/org/utn/ba/tptacsg2/models/inscriptions/Inscripcion.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/models/inscriptions/Inscripcion.java
@@ -4,6 +4,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.utn.ba.tptacsg2.models.actors.Participante;
+import org.utn.ba.tptacsg2.models.events.EstadoEvento;
 import org.utn.ba.tptacsg2.models.events.Evento;
 
 import java.time.LocalDateTime;
@@ -20,5 +21,8 @@ public record Inscripcion (
         Evento evento
 ){
 
+    public Inscripcion (Participante participante, LocalDateTime fechaRegistro, EstadoInscripcion estado, Evento evento){
+        this(null,participante,fechaRegistro,estado,evento);
+    }
 
 }

--- a/backend/src/main/java/org/utn/ba/tptacsg2/models/users/Usuario.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/models/users/Usuario.java
@@ -1,7 +1,11 @@
 package org.utn.ba.tptacsg2.models.users;
 
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
 
+@Document(collation = "usuarios")
 public record Usuario(
+        @Id
         String id,
         String username,
         String passwordHash,

--- a/backend/src/main/java/org/utn/ba/tptacsg2/models/users/Usuario.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/models/users/Usuario.java
@@ -10,5 +10,9 @@ public record Usuario(
         String username,
         String passwordHash,
         Rol rol
-) {}
+) {
+    public Usuario(String username, String passwordHash, Rol rol) {
+        this(null, username, passwordHash, rol);
+    }
+}
 

--- a/backend/src/main/java/org/utn/ba/tptacsg2/repositories/db/EstadoEventoRepositoryDB.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/repositories/db/EstadoEventoRepositoryDB.java
@@ -1,0 +1,6 @@
+package org.utn.ba.tptacsg2.repositories.db;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.utn.ba.tptacsg2.models.events.EstadoEvento;
+
+public interface EstadoEventoRepositoryDB extends MongoRepository<EstadoEvento, String> {}

--- a/backend/src/main/java/org/utn/ba/tptacsg2/repositories/db/EstadoInscripcionRepositoryDB.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/repositories/db/EstadoInscripcionRepositoryDB.java
@@ -1,0 +1,7 @@
+package org.utn.ba.tptacsg2.repositories.db;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.utn.ba.tptacsg2.models.inscriptions.EstadoInscripcion;
+
+
+public interface EstadoInscripcionRepositoryDB extends MongoRepository<EstadoInscripcion, String> {}

--- a/backend/src/main/java/org/utn/ba/tptacsg2/repositories/db/EventoRepositoryDB.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/repositories/db/EventoRepositoryDB.java
@@ -1,0 +1,6 @@
+package org.utn.ba.tptacsg2.repositories.db;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.utn.ba.tptacsg2.models.events.Evento;
+
+public interface EventoRepositoryDB extends MongoRepository<Evento, String> {}

--- a/backend/src/main/java/org/utn/ba/tptacsg2/repositories/db/InscripcionRepositoryDB.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/repositories/db/InscripcionRepositoryDB.java
@@ -1,0 +1,6 @@
+package org.utn.ba.tptacsg2.repositories.db;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.utn.ba.tptacsg2.models.inscriptions.Inscripcion;
+
+public interface InscripcionRepositoryDB extends MongoRepository<Inscripcion, String> {}

--- a/backend/src/main/java/org/utn/ba/tptacsg2/repositories/db/OrganizadorRepositoryDB.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/repositories/db/OrganizadorRepositoryDB.java
@@ -1,0 +1,6 @@
+package org.utn.ba.tptacsg2.repositories.db;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.utn.ba.tptacsg2.models.actors.Organizador;
+
+public interface OrganizadorRepositoryDB extends MongoRepository<Organizador, String> {}

--- a/backend/src/main/java/org/utn/ba/tptacsg2/repositories/db/ParticipanteRepositoryDB.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/repositories/db/ParticipanteRepositoryDB.java
@@ -1,0 +1,6 @@
+package org.utn.ba.tptacsg2.repositories.db;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.utn.ba.tptacsg2.models.actors.Participante;
+
+public interface ParticipanteRepositoryDB extends MongoRepository<Participante, String> {}

--- a/backend/src/main/java/org/utn/ba/tptacsg2/repositories/db/UsuarioRepositoryDB.java
+++ b/backend/src/main/java/org/utn/ba/tptacsg2/repositories/db/UsuarioRepositoryDB.java
@@ -1,0 +1,6 @@
+package org.utn.ba.tptacsg2.repositories.db;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.utn.ba.tptacsg2.models.users.Usuario;
+
+public interface UsuarioRepositoryDB extends MongoRepository<Usuario, String> {}


### PR DESCRIPTION
Opte por la opcion de dejar a mongo manejar los ids por lo tanto hay que crear constructores custom sin ids, lo hice en un par de clases para porbar me parece que es lo ideal. 

Ademas desp cuando venga desde el front simplemente es poner el id del organizador en evento por ejemplo, no te tenes que traer todo el objeto y ya mapea mongo solo. 

Si les parece aplico el cambio en las clases que quedan. En la clase EstadoInscripcion el Id es un final lo cambiaria a que no sea final para que me deje ponerle null al id para que lo ponga bien mongo